### PR TITLE
Add "token" input

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -11,10 +11,28 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 0 * * 1"
 
+defaults:
+  run:
+    shell: sh
+
 jobs:
+  github-token:
+    name: Get GitHub token
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.generate-app-token.outputs.token }}
+    steps:
+      - name: Generate
+        uses: actions/create-github-app-token@v1
+        id: generate-app-token
+        with:
+          app-id: ${{ vars.APP_ID_READONLY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY_READONLY }}
   convert:
     name: Convert
     timeout-minutes: 5
+    needs: [github-token]
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +41,8 @@ jobs:
         to: ["yaml", "json", "xml", "props"]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
       - name: Prepare
         run: |
           echo 's:' > expected.yaml
@@ -48,7 +67,6 @@ jobs:
           echo 's.v = 1' > expected.props
           echo 's.m.0 = t1' >> expected.props
           echo 's.m.1 = t2' >> expected.props
-        shell: sh
       - name: Convert
         uses: ./
         id: convert
@@ -56,26 +74,25 @@ jobs:
           input: expected.${{ matrix.from }}
           from: ${{ matrix.from }}
           to: ${{ matrix.to }}
+          token: ${{ needs.github-token.outputs.value }}
       - name: Save result
         run: echo '${{ steps.convert.outputs.output }}' > actual.${{ matrix.to }}
-        shell: sh
       - name: Print actual file
         run: cat actual.${{ matrix.to }}
-        shell: sh
       - name: Validate
         run: cmp -s "expected.${{ matrix.to }}" "actual.${{ matrix.to }}" || diff "expected.${{ matrix.to }}" "actual.${{ matrix.to }}"
-        shell: sh
       - name: Clean up
+        if: ${{ always() }}
         run: |
           rm -f expected.yaml
           rm -f expected.json
           rm -f expected.xml
           rm -f expected.props
           rm -f actual.${{ matrix.to }}
-        shell: sh
   convert-container:
     name: Convert
     timeout-minutes: 5
+    needs: [github-token]
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +103,8 @@ jobs:
     container:
       image: ${{ matrix.image }}:latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
       - name: Prepare
         run: |
           echo 's:' > expected.yaml
@@ -111,7 +129,6 @@ jobs:
           echo 's.v = 1' > expected.props
           echo 's.m.0 = t1' >> expected.props
           echo 's.m.1 = t2' >> expected.props
-        shell: sh
       - name: Convert
         uses: ./
         id: convert
@@ -119,12 +136,11 @@ jobs:
           input: expected.${{ matrix.from }}
           from: ${{ matrix.from }}
           to: ${{ matrix.to }}
+          token: ${{ needs.github-token.outputs.value }}
       - name: Save result
         run: echo '${{ steps.convert.outputs.output }}' > actual.${{ matrix.to }}
-        shell: sh
       - name: Print actual file
         run: cat actual.${{ matrix.to }}
-        shell: sh
       - name: Install dependencies
         if: ${{ matrix.image == 'centos' }}
         run: |
@@ -132,15 +148,13 @@ jobs:
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
           yum update -y
           yum install diffutils
-        shell: sh
       - name: Validate
         run: cmp -s "expected.${{ matrix.to }}" "actual.${{ matrix.to }}" || diff "expected.${{ matrix.to }}" "actual.${{ matrix.to }}"
-        shell: sh
       - name: Clean up
+        if: ${{ always() }}
         run: |
           rm -f expected.yaml
           rm -f expected.json
           rm -f expected.xml
           rm -f expected.props
           rm -f actual.${{ matrix.to }}
-        shell: sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         stages: ["push"]
   # Other
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v3.1.0
     hooks:
       - id: prettier
         stages: ["commit"]

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Converts data formats interchangeably. The following formats are supported: [XML
 ## Inputs
 
 <!-- prettier-ignore-start -->
-| Name        | Required | Description                      | Possible values                |
-|-------------|----------|----------------------------------|--------------------------------|
-| input       | Yes      | Path to the file to be converted | _&lt;Path&gt;_                 |
-| from        | Yes      | Format of a data in `input` file | `json`, `xml`, `yaml`, `props` |
-| to          | Yes      | Format of a data as a result     | `json`, `xml`, `yaml`, `props` |
+| Name  | Required | Description                               | Possible values                |
+|-------|----------|-------------------------------------------|--------------------------------|
+| input | Yes      | Path to the file to be converted          | _&lt;Path&gt;_                 |
+| from  | Yes      | Format of a data in `input` file          | `json`, `xml`, `yaml`, `props` |
+| to    | Yes      | Format of a data as a result              | `json`, `xml`, `yaml`, `props` |
+| token | No       | The GitHub token or personal access token | _&lt;token&gt;_                |
 <!-- prettier-ignore-end -->
 
 ## Outputs
@@ -26,137 +27,7 @@ Converts data formats interchangeably. The following formats are supported: [XML
 | output | Yes      | Converted data is in a format defined in `to` argument |
 <!-- prettier-ignore-end -->
 
-## Examples
+## Documentation
 
-### 1. YAML to JSON
-
-#### 1.1. Initial data
-
-`docker-compose.yml` is a file to be converted into `JSON` with the following
-content:
-
-```yaml
-version: "3.7"
-services:
-  mongo:
-    image: mongo:4.2.3-bionic
-    networks:
-      - test-network
-
-networks:
-  test-network:
-    name: test-network
-    driver: bridge
-```
-
-#### 1.2. Workflow configuration
-
-```yaml
-name: Convert
-
-on: push
-
-jobs:
-  converter:
-    name: Run converter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - uses: fabasoad/data-format-converter-action@main
-        id: yaml2json
-        with:
-          input: "docker-compose.yml"
-          from: "yaml"
-          to: "json"
-      - name: Print result
-        run: echo "${{ steps.yaml2json.outputs.output }}"
-```
-
-#### 1.3. Result
-
-```json
-{
-  "version": 3.7,
-  "services": {
-    "mongo": {
-      "image": "mongo:4.2.3-bionic",
-      "networks": ["test-network"]
-    }
-  },
-  "networks": {
-    "test-network": {
-      "name": "test-network",
-      "driver": "bridge"
-    }
-  }
-}
-```
-
-### 2. XML to YAML
-
-#### 2.1. Initial data
-
-`person.xml` is a file to be converted into `YAML` with the following
-content:
-
-```xml
-<person>
-    <name>John Doe</name>
-    <age>32</age>
-    <hobbies>Music</hobbies>
-    <hobbies>PC Games</hobbies>
-</person>
-```
-
-#### 2.2. Workflow configuration
-
-```yaml
-name: Convert
-
-on: push
-
-jobs:
-  converter:
-    name: Run converter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - uses: fabasoad/data-format-converter-action@main
-        id: xml2yaml
-        with:
-          input: "person.xml"
-          from: "xml"
-          to: "yaml"
-      - name: Print result
-        run: echo "${{ steps.xml2yaml.outputs.output }}"
-```
-
-#### 2.3. Result
-
-```yaml
-person:
-  name: John Doe
-  age: 32
-  hobbies:
-    - Music
-    - PC Games
-```
-
-## FAQ
-
-> What if `from` and `to` are the same?
-
-There will not be error or any exception in this case. Result will be read from
-`input` and returned as `output`.
-
-> What OS and architectures are supported? I need to understand what type of
-> runners I can use.
-
-The following environments are supported:
-
-- OS: `macOS`, `Windows`, `Ubuntu`, `Alpine`, `CentOS`.
-- Arch: `ARM`, `ARM64`, `x86`, `x64`.
-
-If you find that some of these OS don't work please open an [issue](https://github.com/fabasoad/data-format-converter-action/issues/new?assignees=fabasoad&labels=bug&template=bug_report.md&title=)
-or [PR](https://github.com/fabasoad/data-format-converter-action/compare) with
-the fix. Thanks!
+- [Examples](./docs/Examples.md)
+- [FAQ](./docs/FAQ.md)

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   to:
     description: "Format of a file as a result. Possible values: json, xml, yaml, props."
     required: true
+  token:
+    description: "The GitHub token or personal access token"
+    required: false
+    default: ${{ github.token }}
 outputs:
   output:
     description: "Converted data."
@@ -28,6 +32,7 @@ runs:
       with:
         repository: mikefarah/yq
         excludes: prerelease, draft
+        token: ${{ inputs.token }}
     - name: Collect yq info
       id: info
       env:

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,0 +1,142 @@
+# Examples
+
+## 1. YAML to JSON
+
+### 1.1. Initial data
+
+`docker-compose.yml` is a file to be converted into `JSON` with the following
+content:
+
+```yaml
+version: "3.7"
+services:
+  mongo:
+    image: mongo:4.2.3-bionic
+    networks:
+      - test-network
+
+networks:
+  test-network:
+    name: test-network
+    driver: bridge
+```
+
+### 1.2. Workflow configuration
+
+```yaml
+- uses: fabasoad/data-format-converter-action@v0
+  id: yaml2json
+  with:
+    input: "docker-compose.yml"
+    from: "yaml"
+    to: "json"
+- name: Print result
+  run: echo "${{ steps.yaml2json.outputs.output }}"
+```
+
+### 1.3. Result
+
+```json
+{
+  "version": 3.7,
+  "services": {
+    "mongo": {
+      "image": "mongo:4.2.3-bionic",
+      "networks": ["test-network"]
+    }
+  },
+  "networks": {
+    "test-network": {
+      "name": "test-network",
+      "driver": "bridge"
+    }
+  }
+}
+```
+
+## 2. XML to YAML
+
+### 2.1. Initial data
+
+`person.xml` is a file to be converted into `YAML` with the following
+content:
+
+```xml
+<person>
+    <name>John Doe</name>
+    <age>32</age>
+    <hobbies>Music</hobbies>
+    <hobbies>PC Games</hobbies>
+</person>
+```
+
+### 2.2. Workflow configuration
+
+```yaml
+- uses: fabasoad/data-format-converter-action@v0
+  id: xml2yaml
+  with:
+    input: "person.xml"
+    from: "xml"
+    to: "yaml"
+- name: Print result
+  run: echo "${{ steps.xml2yaml.outputs.output }}"
+```
+
+### 2.3. Result
+
+```yaml
+person:
+  name: John Doe
+  age: 32
+  hobbies:
+    - Music
+    - PC Games
+```
+
+## 3. Use GitHub token
+
+### 3.1. Personal access token (PAT)
+
+1. [Create PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+   with `repo` permission.
+2. [Create repository secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
+   (e.g. `MY_GITHUB_TOKEN`) with the PAT value.
+3. Use the following configuration:
+
+```yaml
+- uses: fabasoad/data-format-converter-action@v0
+  id: xml2yaml
+  with:
+    input: "person.xml"
+    from: "xml"
+    to: "yaml"
+    token: ${{ secrets.MY_GITHUB_TOKEN }}
+```
+
+### 3.2. GitHub App token
+
+1. [Register a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app)
+   with `contents: read` permission.
+2. Create private key and save it somewhere on your local disk.
+3. [Install GitHub App](https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app)
+   to your repository.
+4. [Create repository secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
+   (e.g. `APP_PRIVATE_KEY`) with the private key created on step 2.
+5. Create repository variable (e.g. `APP_ID`) with the GitHub App ID.
+6. Use the following configuration:
+
+```yaml
+- uses: actions/create-github-app-token@v1
+  id: generate-app-token
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+- uses: fabasoad/data-format-converter-action@v0
+  id: xml2yaml
+  with:
+    input: "person.xml"
+    from: "xml"
+    to: "yaml"
+    token: ${{ steps.generate-app-token.outputs.token }}
+```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,27 @@
+# FAQ
+
+> What if `from` and `to` are the same?
+
+There will not be error or any exception in this case. Result will be read from
+`input` and returned as `output`.
+
+> What OS and architectures are supported? I need to understand what type of
+> runners I can use.
+
+The following environments are supported:
+
+- OS: `macOS`, `Windows`, `Ubuntu`, `Alpine`, `CentOS`.
+- Arch: `ARM`, `ARM64`, `x86`, `x64`.
+
+If you find that some of these OS don't work please open an [issue](https://github.com/fabasoad/data-format-converter-action/issues/new?assignees=fabasoad&labels=bug&template=bug_report.md&title=)
+or [PR](https://github.com/fabasoad/data-format-converter-action/compare) with
+the fix. Thanks!
+
+> I have "API rate limit exceeded" error
+
+You need [to pass GitHub token](./Examples.md#3-use-github-token) to `token`
+input of the action in case you have error message below.
+
+```text
+Error: API rate limit exceeded for <IP>. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
+```


### PR DESCRIPTION
- Bump pre-commit/mirrors-prettier from 3.0.3 to 3.1.0
- Use token generated for GitHub app in CI
- Add `token` input